### PR TITLE
change algorithm to compute back-azimuth based purely on unweighted infrasound-transverse coherence.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Authors
 Jordan W. Bishop <br>
 David Fee <br>
 Matthew M. Haney <br>
+Logan Scamfer <br>
 
 
 Acknowledgements and Distribution Statement

--- a/example.py
+++ b/example.py
@@ -3,16 +3,15 @@ from obspy.clients.fdsn import Client
 from tcm import tcm
 from tcm.tools import plotting
 from matplotlib import rcParams
-
-#%%
 rcParams.update({'font.size': 10})
+#%%
 
 # Filter range [Hz]
 freq_min = 10.0
 freq_max = 20.0
 
 # Use 2 Hz narrowband [True] or broadband [False] coherence maxima for calculation
-search_2Hz = True
+search_2Hz = False
 
 # Window length [sec]
 window_length = 15.0
@@ -61,13 +60,14 @@ st.interpolate(sampling_rate=st[0].stats.sampling_rate, method='lanczos', a=15)
 st.detrend(type='linear')
 
 #%% Run the transverse coherence minimization (TCM) algorithm
-baz, sigma, time_smooth, frequency_vector, time, Cxy2, mean_coherence, freq_lim_min, freq_lim_max = tcm.run_tcm(st, freq_min, freq_max, window_length, window_overlap, az_min, az_max, az_delta, search_2Hz) # noqa
+baz, sigma, time_smooth, frequency_vector, time, Cxy2, median_coherence, freq_lim_min, freq_lim_max = tcm.run_tcm(st, freq_min, freq_max, window_length, window_overlap, az_min, az_max, az_delta, search_2Hz) # noqa
 
 #%% Plot the results
 fig, axs = plotting.tcm_plot(st, freq_min, freq_max, baz,
                              time_smooth, frequency_vector, time,
-                             Cxy2, mean_coherence, freq_lim_min, freq_lim_max,
+                             Cxy2, median_coherence, freq_lim_min, freq_lim_max,
                              search_2Hz)
 # Plot uncertainties
 axs[4].scatter(time_smooth, baz + sigma, c='gray', marker='_', linestyle=':')
-axs[4].scatter(time_smooth, baz - sigma, c='gray', marker='_', linestyle=':')
+axs[4].scatter(time_smooth, baz - sigma, c='gray', marker='_', linestyle=':')\
+fig.show()

--- a/tcm/tcm.py
+++ b/tcm/tcm.py
@@ -28,7 +28,7 @@ def run_tcm(st: type[Stream], freq_min: float, freq_max: float, window_length: f
             ``freq_vector`` (array): frequency vector for Cxy2.
             ``time_vector`` (array): time vector for Cxy2.
             ``Cxy2`` (array): Magnitude-squared coherence between the vertical displacement (Z) and the infrasound pressure.
-            ``mean_coherence`` (array):  Mean coherence value across smoothed back-azimuth estimate.
+            ``median_coherence`` (array):  Median coherence value across smoothed back-azimuth estimate.
             ``freq_min_array`` (array): minimum frequency used in the ith time window; defaults to ``freq_min``.
             ``freq_max_array`` (array): maximum frequency used in the ith time window; defaults to ``freq_max``.
 
@@ -52,4 +52,4 @@ def run_tcm(st: type[Stream], freq_min: float, freq_max: float, window_length: f
     # Estimate uncertainty
     TCM.calculate_uncertainty(data, CSM)
 
-    return TCM.baz_final, TCM.sigma, CSM.t[TCM.smvc], CSM.freq_vector, CSM.t, CSM.Cxy2, TCM.mean_coherence, TCM.freq_min_array, TCM.freq_max_array  # noqa
+    return TCM.baz_final, TCM.sigma, CSM.t[TCM.smvc], CSM.freq_vector, CSM.t, CSM.Cxy2, TCM.median_coherence, TCM.freq_min_array, TCM.freq_max_array  # noqa

--- a/tcm/tools/plotting.py
+++ b/tcm/tools/plotting.py
@@ -7,7 +7,7 @@ import numpy as np
 
 colorm = LinearSegmentedColormap.from_list('', ['white', *plt.cm.get_cmap('magma_r').colors])
 
-def tcm_plot(st, freq_min, freq_max, baz, time_smooth, freq_vector, time, Cxy2, mean_coherence, freq_min_array, freq_max_array, search_2Hz):  # noqa
+def tcm_plot(st, freq_min, freq_max, baz, time_smooth, freq_vector, time, Cxy2, median_coherence, freq_min_array, freq_max_array, search_2Hz):  # noqa
     """ Return a plot of the TCM results.
 
     Plots (a) the vertical seismic trace, (b) the magnitude squared coherence
@@ -23,7 +23,7 @@ def tcm_plot(st, freq_min, freq_max, baz, time_smooth, freq_vector, time, Cxy2, 
         freq_vector (array):
         time (array):
         Cxy2 (array):
-        mean_coherence (array):
+        median_coherence (array):
         freq_min_array (array):
         freq_max_array (array):
         search_2Hz: (bool): Calculate and plot 2 Hz coherence band
@@ -107,7 +107,7 @@ def tcm_plot(st, freq_min, freq_max, baz, time_smooth, freq_vector, time, Cxy2, 
             axs[3].add_patch(rect)
 
     # Back-azimuth Estimate
-    sc1 = axs[4].scatter(time_smooth, baz, c=mean_coherence, cmap=cm,
+    sc1 = axs[4].scatter(time_smooth, baz, c=median_coherence, cmap=cm,
                          edgecolors=None, lw=0.3)
     axs[4].set_ylim(0, 360)
     axs[4].set_yticks([0, 90, 180, 270, 360])
@@ -119,7 +119,7 @@ def tcm_plot(st, freq_min, freq_max, baz, time_smooth, freq_vector, time, Cxy2, 
     ctop = p1.y1
     cbaxes = fig.add_axes([p2.x0+p2.width+0.03, cbot, 0.02, ctop-cbot])
     hc = plt.colorbar(sc0, cax=cbaxes)
-    hc.set_label('Max Weighted Coherence')
+    hc.set_label('Median Coherence')
 
     axs[4].xaxis_date()
     axs[4].tick_params(axis='x', labelbottom='on')


### PR DESCRIPTION
Changed algorithm to compute back-azimuth based purely on transverse-infrasound coherence. No vertical-infrasound weighting is applied in the back-azimuth determination. 

Additionally, the coloring for the plotting of the back-azimuth is now determined by the vertical-infrasound coherence rather than the weighted coherence. This prevents cases where there is clear coupling, however the plotting function does not identify a coherent backazimuth estimate.